### PR TITLE
Add runtime check to see if htonll is already defined, e.g. for Mac OS X 10.10

### DIFF
--- a/src/flake.cc
+++ b/src/flake.cc
@@ -38,6 +38,7 @@ static uint64_t make_timestamp(uint64_t offset) {
           tv.tv_usec/1000);
 }
 
+#ifndef HTONLL
 static uint64_t htonll(uint64_t value) {
   // See http://stackoverflow.com/questions/3022552/is-there-any-standard-htonl-like-function-for-64-bits-integers-in-c
 
@@ -55,6 +56,7 @@ static uint64_t htonll(uint64_t value) {
     return value;
   }
 }
+#endif
 
 flake::flake(const uint8_t *machineNumber,
              size_t machineNumberLength,


### PR DESCRIPTION
This fixes a compilation error when installing on OS X Yosemite.
